### PR TITLE
fix: Prevent duplicate athlete workout scores

### DIFF
--- a/src/errors/scores.js
+++ b/src/errors/scores.js
@@ -1,0 +1,5 @@
+const { createError } = require('apollo-errors')
+
+exports.AthleteWorkoutScoreExists = createError('AthleteWorkoutScoreExists', {
+  message: `You've already submitted a score for this workout`
+})

--- a/src/resolvers/mutation/createWorkoutScore.js
+++ b/src/resolvers/mutation/createWorkoutScore.js
@@ -7,9 +7,9 @@ module.exports = {
     { db }
   ) => {
     try {
-      const score = await db.Score.findOne({ athlete, workout })
+      const existingScore = await db.Score.findOne({ athlete, workout })
 
-      if (score) throw new AthleteWorkoutScoreExists()
+      if (existingScore) throw new AthleteWorkoutScoreExists()
 
       const newScore = await new db.Score({
         athlete,

--- a/src/resolvers/mutation/createWorkoutScore.js
+++ b/src/resolvers/mutation/createWorkoutScore.js
@@ -1,3 +1,5 @@
+const { AthleteWorkoutScoreExists } = require('../../errors/scores')
+
 module.exports = {
   createWorkoutScore: async (
     root,
@@ -5,28 +7,32 @@ module.exports = {
     { db }
   ) => {
     try {
-      const score = await new db.Score({
+      const score = await db.Score.findOne({ athlete, workout })
+
+      if (score) throw new AthleteWorkoutScoreExists()
+
+      const newScore = await new db.Score({
         athlete,
         createdAt: new Date(),
         value,
         workout
       })
 
-      await score.save()
+      await newScore.save()
 
       await db.Workout.findByIdAndUpdate(
         workout,
-        { $push: { scores: score } },
+        { $push: { scores: newScore } },
         { new: true }
       )
 
       await db.Athlete.findByIdAndUpdate(
         athlete,
-        { $push: { scores: score } },
+        { $push: { scores: newScore } },
         { new: true }
       )
 
-      return score
+      return newScore
     } catch (e) {
       return e
     }


### PR DESCRIPTION
Check for an existing score for an athlete when creating a new score for a workout. Will prevent duplicate entries.